### PR TITLE
fix(fe3): wrong app for squareRoot federation

### DIFF
--- a/fe3/pages/index.js
+++ b/fe3/pages/index.js
@@ -3,7 +3,7 @@ import Image from 'next/image'
 import styles from '../styles/Home.module.css'
 
 const Header = React.lazy( () => import('fe1/header'));
-const squareRoot = React.lazy( () => import('app1/getSquareRoot'));
+const squareRoot = React.lazy( () => import('fe2/getSquareRoot'));
 
 export default function Home() {
   return (
@@ -19,3 +19,4 @@ export default function Home() {
     </div>
   )
 }
+


### PR DESCRIPTION
Changed `app1` with `fe2`, as the imported federated module is not called `app1`